### PR TITLE
Fix an issue in `ArrayView<T>` incorrectly returned a mutable reference

### DIFF
--- a/Ramstack.Structures/Collections/ArrayView`1.cs
+++ b/Ramstack.Structures/Collections/ArrayView`1.cs
@@ -37,7 +37,7 @@ public readonly struct ArrayView<T> : IReadOnlyList<T>
     public bool IsDefault => _array is null;
 
     /// <inheritdoc cref="IReadOnlyList{T}.this"/>
-    public ref T this[int index]
+    public ref readonly T this[int index]
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
@@ -202,7 +202,7 @@ public readonly struct ArrayView<T> : IReadOnlyList<T>
     /// A reference to the element of the <see cref="ArrayView{T}"/> at index zero.
     /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ref T GetPinnableReference()
+    public ref readonly T GetPinnableReference()
     {
         // To match the behavior of ReadOnlySpan<T>
 


### PR DESCRIPTION
Fix an issue where some methods in `ArrayView<T>` incorrectly returned a mutable reference

- Update the indexer to return `ref readonly T` instead of `ref T`.
- Update the `GetPinnableReference` method to return `ref readonly T`.