### PR TITLE
Downgrade S.C.Immutable package for .NET 6.0 target

### DIFF
--- a/Ramstack.Structures.Tests/Collections/ArrayViewTests.cs
+++ b/Ramstack.Structures.Tests/Collections/ArrayViewTests.cs
@@ -416,7 +416,7 @@ public class ArrayViewTests
     public void AsView(string? value)
     {
         var list = value?.ToCharArray();
-        var immutable = value.AsSpan().ToImmutableArray();
+        var immutable = value.AsSpan().ToArray().ToImmutableArray();
 
         Assert.That(
             list.AsView(),
@@ -437,7 +437,7 @@ public class ArrayViewTests
     public void AsView_Index(string? value, int index)
     {
         var list = value?.ToCharArray();
-        var immutable = value.AsSpan().ToImmutableArray();
+        var immutable = value.AsSpan().ToArray().ToImmutableArray();
 
         Assert.That(
             list.AsView(index),
@@ -459,7 +459,7 @@ public class ArrayViewTests
     public void AsView_Range(string? value, int index, int length)
     {
         var list = value?.ToCharArray();
-        var immutable = value.AsSpan().ToImmutableArray();
+        var immutable = value.AsSpan().ToArray().ToImmutableArray();
 
         Assert.That(
             list.AsView(index, length),
@@ -477,7 +477,7 @@ public class ArrayViewTests
     public void AsView_InvalidIndex_ShouldThrow(string? value, int index)
     {
         var list = value?.ToCharArray();
-        var immutable = value.AsSpan().ToImmutableArray();
+        var immutable = value.AsSpan().ToArray().ToImmutableArray();
 
         Assert.That(
             () => list.AsView(index),
@@ -499,7 +499,7 @@ public class ArrayViewTests
     public void AsView_InvalidRange_ShouldThrow(string? value, int index, int length)
     {
         var list = value?.ToCharArray();
-        var immutable = value.AsSpan().ToImmutableArray();
+        var immutable = value.AsSpan().ToArray().ToImmutableArray();
 
         Assert.That(
             () => list.AsView(index, length),

--- a/Ramstack.Structures.sln
+++ b/Ramstack.Structures.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59

--- a/Ramstack.Structures/Collections/ArrayView`1.cs
+++ b/Ramstack.Structures/Collections/ArrayView`1.cs
@@ -256,8 +256,14 @@ public readonly struct ArrayView<T> : IReadOnlyList<T>
     /// <returns>
     /// An array view representation of the read-only array.
     /// </returns>
-    public static implicit operator ArrayView<T>(ImmutableArray<T> array) =>
-        ImmutableCollectionsMarshal.AsArray(array);
+    public static implicit operator ArrayView<T>(ImmutableArray<T> array)
+    {
+        #if NET8_0_OR_GREATER
+        return ImmutableCollectionsMarshal.AsArray(array);
+        #else
+        return Unsafe.As<ImmutableArray<T>, ReadOnlyArray<T>>(ref array).AsView();
+        #endif
+    }
 
     /// <summary>
     /// Defines an implicit conversion of an array view to the <see cref="ReadOnlyMemory{T}"/>.

--- a/Ramstack.Structures/Collections/ImmutableArrayExtensions.cs
+++ b/Ramstack.Structures/Collections/ImmutableArrayExtensions.cs
@@ -8,6 +8,16 @@ namespace Ramstack.Collections;
 public static class ImmutableArrayExtensions
 {
     /// <summary>
+    /// Returns a <see cref="ReadOnlyArray{T}"/> over an immutable array.
+    /// </summary>
+    /// <param name="value">The immutable array.</param>
+    /// <returns>
+    /// The read-only array over an immutable array.
+    /// </returns>
+    public static ReadOnlyArray<T> AsReadOnlyArray<T>(this ImmutableArray<T> value) =>
+        value;
+
+    /// <summary>
     /// Creates an <see cref="ArrayView{T}"/> over an immutable array.
     /// </summary>
     /// <param name="value">The immutable array to wrap.</param>
@@ -15,7 +25,7 @@ public static class ImmutableArrayExtensions
     /// The read-only view of the array.
     /// </returns>
     public static ArrayView<T> AsView<T>(this ImmutableArray<T> value) =>
-        ImmutableCollectionsMarshal.AsArray(value).AsView();
+        value.AsReadOnlyArray().AsView();
 
     /// <summary>
     /// Creates an <see cref="ArrayView{T}"/> over an immutable array starting at a specified position to the end of the array.
@@ -26,7 +36,7 @@ public static class ImmutableArrayExtensions
     /// The read-only view of the array.
     /// </returns>
     public static ArrayView<T> AsView<T>(this ImmutableArray<T> value, int index) =>
-        ImmutableCollectionsMarshal.AsArray(value).AsView(index);
+        value.AsReadOnlyArray().AsView(index);
 
     /// <summary>
     /// Creates an <see cref="ArrayView{T}"/> over an immutable array starting at a specified position for a specified length.
@@ -38,5 +48,5 @@ public static class ImmutableArrayExtensions
     /// The read-only view of the array.
     /// </returns>
     public static ArrayView<T> AsView<T>(this ImmutableArray<T> value, int index, int count) =>
-        ImmutableCollectionsMarshal.AsArray(value).AsView(index, count);
+        value.AsReadOnlyArray().AsView(index, count);
 }

--- a/Ramstack.Structures/Collections/ReadOnlyArray`1.cs
+++ b/Ramstack.Structures/Collections/ReadOnlyArray`1.cs
@@ -303,12 +303,18 @@ public readonly struct ReadOnlyArray<T> : IReadOnlyList<T>, IEquatable<ReadOnlyA
     /// <returns>
     /// A read-only array.
     /// </returns>
-    public static implicit operator ReadOnlyArray<T>(ImmutableArray<T> array) =>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator ReadOnlyArray<T>(ImmutableArray<T> array)
+    {
+        #if NET8_0_OR_GREATER
+        return new ReadOnlyArray<T>(ImmutableCollectionsMarshal.AsArray(array)!);
+        #else
         //
         // https://github.com/dotnet/runtime/issues/83141#issuecomment-1460324087
-        // Unsafe.As<ImmutableArray<T>, ReadOnlyArray<T>>(ref array);
         //
-        new(ImmutableCollectionsMarshal.AsArray(array)!);
+        return Unsafe.As<ImmutableArray<T>, ReadOnlyArray<T>>(ref array);
+        #endif
+    }
 
     /// <summary>
     /// Returns a <see cref="ImmutableArray{T}"/> array from the <paramref name="array"/>.
@@ -317,8 +323,18 @@ public readonly struct ReadOnlyArray<T> : IReadOnlyList<T>, IEquatable<ReadOnlyA
     /// <returns>
     /// A read-only array.
     /// </returns>
-    public static implicit operator ImmutableArray<T>(ReadOnlyArray<T> array) =>
-        ImmutableCollectionsMarshal.AsImmutableArray(array.Inner);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static implicit operator ImmutableArray<T>(ReadOnlyArray<T> array)
+    {
+        #if NET8_0_OR_GREATER
+        return ImmutableCollectionsMarshal.AsImmutableArray(array.Inner);
+        #else
+        //
+        // https://github.com/dotnet/runtime/issues/83141#issuecomment-1460324087
+        //
+        return Unsafe.As<ReadOnlyArray<T>, ImmutableArray<T>>(ref array);
+        #endif
+    }
 
     /// <summary>
     /// Returns a <see cref="ReadOnlySpan{T}"/> from the <paramref name="array"/>.

--- a/Ramstack.Structures/Ramstack.Structures.csproj
+++ b/Ramstack.Structures/Ramstack.Structures.csproj
@@ -61,7 +61,7 @@ Ramstack.Collections.ReadOnlyArray&lt;T&gt;</Description>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Due to some dependencies in some projects, a NuGet warning `NU1605` about version downgrades was occurring.